### PR TITLE
Add Animation Import(s) to NLA Track List

### DIFF
--- a/addons/io_scene_swbf_msh/__init__.py
+++ b/addons/io_scene_swbf_msh/__init__.py
@@ -13,9 +13,9 @@ bl_info = {
 }
 
 # Taken from glTF-Blender-IO, because I do not understand Python that well
-# (this is the first thing of substance I've created in it) and just wanted 
+# (this is the first thing of substance I've created in it) and just wanted
 # script reloading to work.
-# 
+#
 # https://github.com/KhronosGroup/glTF-Blender-IO
 #
 # Copyright 2018-2019 The glTF-Blender-IO authors.
@@ -124,7 +124,7 @@ class ExportMSH(Operator, ExportHelper):
 
 
         scene, armature_obj = create_scene(
-                                generate_triangle_strips=self.generate_triangle_strips, 
+                                generate_triangle_strips=self.generate_triangle_strips,
                                 apply_modifiers=self.apply_modifiers,
                                 export_target=self.export_target,
                                 skel_only=self.animation_export != 'NONE') # Exclude geometry data (except root stuff) if we're doing anims
@@ -141,7 +141,7 @@ class ExportMSH(Operator, ExportHelper):
             set_scene_animation(scene, armature_obj)
             write_scene_to_file(self.filepath, scene)
 
-        elif self.animation_export == 'BATCH':    
+        elif self.animation_export == 'BATCH':
             export_dir = self.filepath if os.path.isdir(self.filepath) else os.path.dirname(self.filepath)
 
             for action in bpy.data.actions:
@@ -162,14 +162,14 @@ def menu_func_export(self, context):
 
 
 class ImportMSH(Operator, ImportHelper):
-    """ Import an SWBF .msh file. """
+    """ Import SWBF .msh file(s). """
 
     bl_idname = "swbf_msh.import"
     bl_label = "Import SWBF .msh File(s)"
     filename_ext = ".msh"
 
     files: CollectionProperty(
-            name="File Path",
+            name="File Path(s)",
             type=bpy.types.OperatorFileListElement,
             )
 
@@ -181,7 +181,7 @@ class ImportMSH(Operator, ImportHelper):
 
     animation_only: BoolProperty(
         name="Import Animation(s)",
-        description="Import on or more animations from the selected files and append each as a new Action to currently selected Armature.",
+        description="Import one or more animations from the selected files and append each as a new Action to currently selected Armature.",
         default=False
     )
 
@@ -193,9 +193,9 @@ class ImportMSH(Operator, ImportHelper):
             if filepath.endswith(".zaabin") or filepath.endswith(".zaa"):
                 extract_and_apply_munged_anim(filepath)
             else:
-                with open(filepath, 'rb') as input_file:              
+                with open(filepath, 'rb') as input_file:
                     scene = read_scene(input_file, self.animation_only)
-                    
+
                 if not self.animation_only:
                     extract_scene(filepath, scene)
                 else:

--- a/addons/io_scene_swbf_msh/msh_anim_to_blend.py
+++ b/addons/io_scene_swbf_msh/msh_anim_to_blend.py
@@ -43,7 +43,6 @@ def extract_and_apply_anim(filename : str, scene : Scene):
                 if anim_name == nt.strips[0].name:
                     arma.animation_data.nla_tracks.remove(nt)
 
-
         action = bpy.data.actions.new(anim_name)
         action.use_fake_user = True
 
@@ -106,6 +105,5 @@ def extract_and_apply_anim(filename : str, scene : Scene):
                     fcurve_loc_y.keyframe_points.insert(i,t.y)
                     fcurve_loc_z.keyframe_points.insert(i,t.z)
 
-        arma.animation_data.action = action
         track = arma.animation_data.nla_tracks.new()
         track.strips.new(action.name, action.frame_range[0], action)

--- a/addons/io_scene_swbf_msh/msh_anim_to_blend.py
+++ b/addons/io_scene_swbf_msh/msh_anim_to_blend.py
@@ -105,5 +105,6 @@ def extract_and_apply_anim(filename : str, scene : Scene):
                     fcurve_loc_y.keyframe_points.insert(i,t.y)
                     fcurve_loc_z.keyframe_points.insert(i,t.z)
 
+        arma.animation_data.action = action
         track = arma.animation_data.nla_tracks.new()
         track.strips.new(action.name, action.frame_range[0], action)


### PR DESCRIPTION
I wish github had an ignore white space changes as part of the change view. =/

Anyway, this is a WIP patch to enhance importing multiple animations in 2.82+. I noticed that selecting multiple animation files and importing still only showed one animation as brought in the Track list. This patch additionally pushes the animation(s) to the NLA Tracks whereas before it was just getting setup in:

`bpy.data.actions.new`

Besides just bulk importing of animations, my use case is for exporting to glTF and importing to Godot. Adding these to the NLA Tracks list fixes glTF exports such that Godot sees and can play the given animations automagically.
